### PR TITLE
Fixing error on trying to introduce locks too soon

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
       "nora-outlet": "build/nodes/nora-outlet.js",
       "nora-light": "build/nodes/nora-light.js",
       "nora-garage": "build/nodes/nora-garage.js",
-      "nora-lock": "build/nodes/nora-lock.js"
     }
   }
 }


### PR DESCRIPTION
Just saw the error posted in the issues. I thought I had cleared out all the lock code in the node base. Fixed it here.  Sorry about that.