### PR TITLE
Two-factor authentication

### DIFF
--- a/src/nodes/nora-garage.html
+++ b/src/nodes/nora-garage.html
@@ -46,6 +46,16 @@
             closevalueType: {
                 value: 'bool'
             },
+            twoFactor: {
+                value: false,
+            },
+                twoFactorMode: {
+                value: 'ack',
+            },
+                twoFactorPin: {
+                value: 1234,
+                validate: RED.validators.number()
+            },
         },
         inputs: 1,
         outputs: 1,
@@ -54,6 +64,26 @@
             return this.name || this.devicename || 'garage';
         },
         oneditprepare: function () {
+            var updatetwoFactorMode = function () {
+            let twoFact = $('#node-input-twoFactor').is(':checked')
+            let mode = $('#node-input-twoFactorMode').val();
+            if ( (twoFact == true) && (mode == 'pin')) {
+                    $('#node-input-twoFactorPin-row').show();
+                } else {
+                    $('#node-input-twoFactorPin-row').hide();
+                }
+            };
+            updatetwoFactorMode ();
+            $('#node-input-twoFactor').change(function () {
+                if (this.checked) {
+                    $('#node-input-twoFactorMode-row').show();
+                } else {
+                    $('#node-input-twoFactorMode-row').hide();
+                    $('#node-input-twoFactorPin-row').hide();
+                }
+            });
+            $('#node-input-twoFactor').change(updatetwoFactorMode);
+            $('#node-input-twoFactorMode').change(updatetwoFactorMode);
             $('#node-input-openvalue').typedInput({
                 default: 'bool',
                 typeField: $("#node-input-openvalueType"),

--- a/src/nodes/nora-garage.html
+++ b/src/nodes/nora-garage.html
@@ -122,6 +122,21 @@
         <input type="hidden" id="node-input-closevalueType">
     </div>
     <div class="form-row">
+        <label style="width:auto" for="node-input-twoFactor"><i class="fa fa-key"></i>&nbsp;&nbsp;Two-factor authentication:&nbsp;&nbsp;&nbsp;&nbsp;</label>
+        <input type="checkbox" id="node-input-twoFactor" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+    <div class="form-row hidden" id="node-input-twoFactorMode-row">
+        <label for="node-input-twoFactorMode">&nbsp;&nbsp;Mode</label>
+        <select id="node-input-twoFactorMode" style="width:70%;">
+            <option value="ack">Acknowledgement (yes or no)</option>
+            <option value="pin">PIN authentication</option>
+        </select>
+    </div>
+    <div class="form-row hidden" id="node-input-twoFactorPin-row">
+        <label for="node-input-twoFactorPin">&nbsp;&nbsp;PIN</label>
+        <input type="text" id="node-input-twoFactorPin">
+    </div>
+    <div class="form-row">
         <label for="node-input-roomhint"><i class="fa fa-i-cursor"></i> Room Hint   </label>
         <input type="text" id="node-input-roomhint">
     </div>

--- a/src/nodes/nora-garage.ts
+++ b/src/nodes/nora-garage.ts
@@ -37,6 +37,8 @@ module.exports = function (RED) {
                     name: config.devicename,
                     roomHint: config.roomhint || undefined,
                     state: state$.value,
+                    twoFactor: config.twoFactor ? config.twoFactorMode : undefined,
+                    pin: ( config.twoFactor && config.twoFactorMode == 'pin') ? (config.twoFactorPin+'') : undefined
                 })),
                 publishReplay(1),
                 refCount(),

--- a/src/nodes/nora-lock.html
+++ b/src/nodes/nora-lock.html
@@ -68,6 +68,16 @@
             unjammedValueType: {
                 value: 'bool'
             },
+            twoFactor: {
+                value: false,
+            },
+                twoFactorMode: {
+                value: 'ack',
+            },
+                twoFactorPin: {
+                value: 1234,
+                validate: RED.validators.number()
+            },
         },
         inputs: 1,
         outputs: 1,
@@ -76,6 +86,26 @@
             return this.name || this.devicename || 'lock';
         },
         oneditprepare: function () {
+            var updatetwoFactorMode = function () {
+            let twoFact = $('#node-input-twoFactor').is(':checked')
+            let mode = $('#node-input-twoFactorMode').val();
+            if ( (twoFact == true) && (mode == 'pin')) {
+                    $('#node-input-twoFactorPin-row').show();
+                } else {
+                    $('#node-input-twoFactorPin-row').hide();
+                }
+            };
+            updatetwoFactorMode ();
+            $('#node-input-twoFactor').change(function () {
+                if (this.checked) {
+                    $('#node-input-twoFactorMode-row').show();
+                } else {
+                    $('#node-input-twoFactorMode-row').hide();
+                    $('#node-input-twoFactorPin-row').hide();
+                }
+            });
+            $('#node-input-twoFactor').change(updatetwoFactorMode);
+            $('#node-input-twoFactorMode').change(updatetwoFactorMode);
             $('#node-input-lockValue').typedInput({
                 default: 'bool',
                 typeField: $("#node-input-lockValueType"),
@@ -145,6 +175,21 @@
         <label for="node-input-unjammedValue" style="padding-left:20px; margin-right:-20px">Unjammed</label>
         <input type="text" id="node-input-unjammedValue" style="width:70%">
         <input type="hidden" id="node-input-unjammedValueType">
+    </div>
+    <div class="form-row">
+        <label style="width:auto" for="node-input-twoFactor"><i class="fa fa-key"></i>&nbsp;&nbsp;Two-factor authentication:&nbsp;&nbsp;&nbsp;&nbsp;</label>
+        <input type="checkbox" id="node-input-twoFactor" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+    <div class="form-row hidden" id="node-input-twoFactorMode-row">
+        <label for="node-input-twoFactorMode">&nbsp;&nbsp;Mode</label>
+        <select id="node-input-twoFactorMode" style="width:70%;">
+            <option value="ack">Acknowledgement (yes or no)</option>
+            <option value="pin">PIN authentication</option>
+        </select>
+    </div>
+    <div class="form-row hidden" id="node-input-twoFactorPin-row">
+        <label for="node-input-twoFactorPin">&nbsp;&nbsp;PIN</label>
+        <input type="text" id="node-input-twoFactorPin">
     </div>
     <div class="form-row">
         <label for="node-input-topic" style="padding-left:20px; margin-right:-20px" ><i class="fa fa-tasks"></i> Topic</label>

--- a/src/nodes/nora-lock.ts
+++ b/src/nodes/nora-lock.ts
@@ -44,6 +44,8 @@ module.exports = function (RED) {
                     name: config.devicename,
                     roomHint: config.roomhint || undefined,
                     state: state$.value,
+                    twoFactor: config.twoFactor ? config.twoFactorMode : undefined,
+                    pin: ( config.twoFactor && config.twoFactorMode == 'pin') ? (config.twoFactorPin+'') : undefined
                 })),
                 publishReplay(1),
                 refCount(),


### PR DESCRIPTION
Allow enable Two-factor authentication on the **lock** and **garage** devices if they are controlled by Google Assistant (it's not authentication for inputs by Node-RED). It's not required any change on server service.
Supported authentication:
- basic acknowledgement (yes or no)
- pin code (only numbers)